### PR TITLE
Fix a null exception in report status

### DIFF
--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -166,7 +166,7 @@ JSON
         failure_event = client.events.enum(limit: 30).find do |event|
           event.resource_status =~ /_FAILED$/
         end
-        failure_reason = failure_event.nil ? "Unknown failure reason" : failure_event.resource_status_reason
+        failure_reason = failure_event.nil? ? "Unknown failure reason" : failure_event.resource_status_reason
         if failure_reason =~ /stack policy/
           raise StackPolicyError.new failure_reason
         else

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -166,7 +166,7 @@ JSON
         failure_event = client.events.enum(limit: 30).find do |event|
           event.resource_status =~ /_FAILED$/
         end
-        failure_reason = failure_event.resource_status_reason
+        failure_reason = failure_event.nil ? "Unknown failure reason" : failure_event.resource_status_reason
         if failure_reason =~ /stack policy/
           raise StackPolicyError.new failure_reason
         else


### PR DESCRIPTION
If, for whatever reason, an event ending with _FAILED is not found in the last 30 events, stacker currently crashes with a null exception.

This just makes sure it doesn't, and so at least we'll see the name of the stack and the status of the crash.
