### PR TITLE
Making logging log immediately to console

### DIFF
--- a/lib/stacker/logging.rb
+++ b/lib/stacker/logging.rb
@@ -50,6 +50,7 @@ module Stacker
 
     def logger
       @logger ||= begin
+        STDOUT.sync = true
         logger = Logger.new STDOUT
         logger.level = Logger::DEBUG
         logger.formatter = proc { |_, _, _, msg| "#{Time.new}: #{msg}\n" }


### PR DESCRIPTION
So apparently you can get the logger to log straight out to console instead of when the process ends by setting `sync = true`

source:

http://stackoverflow.com/questions/5381082/can-the-standard-ruby-logger-be-configured-to-flush-after-every-message
