### PR TITLE
Adding disable rollback option to stack creation

### DIFF
--- a/lib/stacker/cli.rb
+++ b/lib/stacker/cli.rb
@@ -22,6 +22,9 @@ module Stacker
     method_option :force, type: :boolean, default: false,
       banner: 'do not ask for permission'
 
+    method_option :disable_rollback, type: :boolean, default: false,
+      banner: 'disable rollback for stack creation'
+
     def initialize(*args); super(*args) end
 
     desc "init [PATH]", "Create stacker project directories"
@@ -77,7 +80,7 @@ module Stacker
           Stacker.logger.info formatted_time stack_name, 'updated', time
         else
           time = Benchmark.realtime do
-            stack.create
+            stack.create disable_rollback: options['disable_rollback']
           end
           Stacker.logger.info formatted_time stack_name, 'created', time
         end

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -83,11 +83,14 @@ JSON
       end
     end
 
-    def create blocking = true
+    def create options = {}
       if exists?
         Stacker.logger.warn 'Stack already exists'
         return
       end
+
+      blocking = options.fetch(:blocking, true)
+      disable_rollback = options.fetch(:disable_rollback, false)
 
       if parameters.missing.any?
         raise MissingParameters.new(
@@ -102,7 +105,7 @@ JSON
         template.local,
         parameters: parameters.resolved,
         capabilities: capabilities.local,
-        disable_rollback: true
+        disable_rollback: disable_rollback
       )
 
       sleep 90


### PR DESCRIPTION
This PR adds in functionality to create a stack with rollback disabled

Its exposed via the CLI as option `--disable-rollback`

@ebh don't commit this until you're ready on the other side.
