### PR TITLE
Applied non-breaking error handling for "no updates are to be performed"

### DIFF
--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -24,28 +24,28 @@ module Stacker
       description
       exists?
       last_updated_time   
-	  stack_status	
+    stack_status  
       status_reason
     ]
 
     SAFE_UPDATE_POLICY = <<-JSON
-{
-  "Statement" : [
     {
-      "Effect" : "Deny",
-      "Action" : ["Update:Replace", "Update:Delete"],
-      "Principal" : "*",
-      "Resource" : "*"
-    },
-    {
-      "Effect" : "Allow",
-      "Action" : "Update:*",
-      "Principal" : "*",
-      "Resource" : "*"
+      "Statement" : [
+        {
+          "Effect" : "Deny",
+          "Action" : ["Update:Replace", "Update:Delete"],
+          "Principal" : "*",
+          "Resource" : "*"
+        },
+        {
+          "Effect" : "Allow",
+          "Action" : "Update:*",
+          "Principal" : "*",
+          "Resource" : "*"
+        }
+      ]
     }
-  ]
-}
-JSON
+    JSON
 
     attr_reader :region, :name, :options
 
@@ -54,8 +54,8 @@ JSON
     end
 
     def client
-	  @client = (region.client.describe_stacks stack_name: name)[0]
-	  return @client[0]
+      @client = (region.client.describe_stacks stack_name: name)[0]
+      return @client[0]
     end
 
     delegate *CLIENT_METHODS, to: :client
@@ -77,21 +77,21 @@ JSON
       @capabilities ||= Capabilities.new self
     end
 
-    def outputs  
-	  @outputs = Hash[client.outputs.map { |output| [ output.output_key, output.output_value ] }]  
-	  return @outputs
+    def outputs
+      @outputs = Hash[client.outputs.map { |output| [ output.output_key, output.output_value ] }]
+      return @outputs
       # leaving the following code block commented out for future improvements.
       #@outputs ||= begin
       #  return {} unless complete?
-	    #	puts "calling hash"
+      # puts "calling hash"
       #  Hash[client.outputs.map { |output| [ output.output_key, output.output_value ] }]
       #end
     end
 
     def create blocking = true
       # if exists?
-        # Stacker.logger.warn 'Stack already exists'
-        # return
+      # Stacker.logger.warn 'Stack already exists'
+      # return
       # end
 
       if parameters.missing.any?
@@ -101,10 +101,10 @@ JSON
       end
 
       Stacker.logger.info 'Creating stack'
-		
-	  hashParams = parameters.resolved.map { |key, value| {"parameter_key" => key, "parameter_value" => value} }
-	  
-	  
+
+      hashParams = parameters.resolved.map { |key, value| {"parameter_key" => key, "parameter_value" => value} }
+
+
       region.client.create_stack(
         stack_name: name,
         template_body: template.localStr,
@@ -119,7 +119,7 @@ JSON
     end
 
     def update options = {}
-	Stacker.logger.info 'update stack called'
+      Stacker.logger.info 'update stack called'
       options.assert_valid_keys(:blocking, :allow_destructive)
 
       blocking = options.fetch(:blocking, true)
@@ -132,21 +132,21 @@ JSON
       end
 
       Stacker.logger.info 'Updating stack'
-	  
-	  hashParams = parameters.resolved.map { |key, value| {"parameter_key" => key, "parameter_value" => value} }
-	  
-	   update_params = {
-	     stack_name: name,
-         template_body: template.localStr,
-         parameters: hashParams,
-         capabilities: capabilities.local
-       }
+
+      hashParams = parameters.resolved.map { |key, value| {"parameter_key" => key, "parameter_value" => value} }
+
+      update_params = {
+        stack_name: name,
+        template_body: template.localStr,
+        parameters: hashParams,
+        capabilities: capabilities.local
+      }
 
       unless allow_destructive
         update_params[:stack_policy_during_update_body] = SAFE_UPDATE_POLICY
       end
 
-	  region.client.update_stack(update_params)
+      region.client.update_stack(update_params)
 
       wait_while_status 'UPDATE_IN_PROGRESS' if blocking
     rescue Aws::CloudFormation::Errors::ValidationError => err
@@ -182,9 +182,9 @@ JSON
       end
     end
 
-    def wait_while_status wait_status 
+    def wait_while_status wait_status
       while flush_cache(:stack_status) && ((region.client.describe_stacks stack_name: name)[0])[0].stack_status == wait_status
-		report_status
+        report_status
         sleep 5
       end
       report_status
@@ -192,4 +192,3 @@ JSON
 
   end
 end
-

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -154,7 +154,7 @@ JSON
       when /does not exist/
         raise DoesNotExistError.new err.message
       when /No updates/
-        raise UpToDateError.new err.message
+        Stacker.logger.info 'No real update took place. In order to apply these updates some existing resoources need to be updated'
       else
         raise Error.new err.message
       end

--- a/lib/stacker/stack/template.rb
+++ b/lib/stacker/stack/template.rb
@@ -3,7 +3,6 @@ require 'json'
 require 'memoist'
 require 'stacker/differ'
 require 'stacker/stack/component'
-require 'pry'
 
 module Stacker
   class Stack

--- a/lib/stacker/stack/template.rb
+++ b/lib/stacker/stack/template.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'memoist'
 require 'stacker/differ'
 require 'stacker/stack/component'
+require 'pry'
 
 module Stacker
   class Stack
@@ -29,13 +30,7 @@ module Stacker
       end
 	  
 	  def localStr
-        @localstr ||= begin
-          if exists?
-            templatestr = File.read path
-          else
-            {}
-          end
-        end
+        JSONFormatter.format(local)
       end
 
       def remote


### PR DESCRIPTION
During Cloudformation update, if only outputs get affected (but if that change does not make any resource level change in the actual update process) than AWS returns an exception with "no updates are to be performed" description. When Stacker receives that exception it would have stopped its execution completely. 

These changes make sure in such case, stacker continues with its other tasks. 
Few code formatting and refactoring also made its way into this pull request.
