### PR TITLE
Correctly handling rollbacks

### DIFF
--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -25,7 +25,7 @@ module Stacker
       exists?
       last_updated_time   
 	  stack_status	
-      status_reason
+      stack_status_reason
     ]
 
     SAFE_UPDATE_POLICY = <<-JSON
@@ -164,13 +164,8 @@ JSON
 
     def report_status
       case stack_status
-      when /_COMPLETE$/
-        Stacker.logger.info "#{name} Status => #{stack_status}"
-      when /ROLLBACK_IN_PROGRESS$/, /_FAILED$/
-        failure_event = client.events.enum(limit: 30).find do |event|
-          event.resource_status =~ /_FAILED$/
-        end
-        failure_reason = failure_event.nil? ? "Unknown failure reason" : failure_event.resource_status_reason
+      when /_FAILED$/, /ROLLBACK/
+        failure_reason = stack_status_reason ? stack_status_reason : "Unknown failure reason"
         if failure_reason =~ /stack policy/
           raise StackPolicyError.new failure_reason
         else

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -183,7 +183,7 @@ JSON
     end
 
     def wait_while_status wait_status 
-      while flush_cache(:stack_status) && ((region.client.describe_stacks stack_name: name)[0])[0].stack_status == wait_status
+      while flush_cache("stack_status") && client.stack_status == wait_status
 		report_status
         sleep 5
       end

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -19,6 +19,9 @@ module Stacker
 
     extend Memoist
 
+    # 
+    # This constant contains all memoized methods of the client object
+    # 
     CLIENT_METHODS = %w[
       creation_time
       description
@@ -162,6 +165,12 @@ JSON
 
     private
 
+    # 
+    # This method accesses current objects' stack_status method and prints out the status of the stack.
+    # however, If the status is "FAILED" OR "ROLLBACK" then this method attempts to retrieve status reason. Using that reason this method
+    # throws an exception. 
+    # 
+    # @return [void] Prints out current status of the stack. 
     def report_status
       case stack_status
       when /_FAILED$/, /ROLLBACK/
@@ -177,6 +186,12 @@ JSON
       end
     end
 
+    # 
+    # Waits until status of the stack chages to "wait_status" 
+    # @param wait_status [string] expected status of the cloudformation
+    # 
+    # @return [void] As soon as the stack status changes to the expected status this method returns.
+    # 
     def wait_while_status wait_status 
       while flush_cache("stack_status") && client.stack_status == wait_status
 		report_status


### PR DESCRIPTION
A bug is fixed when during update if stack fail to continue its operation and performs a rollback, Stacker does not raise exception (with rollback reasoning). it is fixed now.
