### PR TITLE
Dop-129998 fix error uninitialized constant stacker stack template aw s

### DIFF
--- a/lib/stacker/stack/template.rb
+++ b/lib/stacker/stack/template.rb
@@ -34,7 +34,7 @@ module Stacker
 
       def remote
 		@remote ||= JSON.parse (stack.region.client.get_template stack_name: client.stack_name).template_body
-      rescue AwS::CloudFormation::Errors::ValidationError => err
+      rescue ::Aws::CloudFormation::Errors::ValidationError => err
         if err.message =~ /does not exist/
           raise DoesNotExistError.new err.message
         else


### PR DESCRIPTION
## Jira card
https://ansarada.atlassian.net/browse/DOP-129998

## Description
Fix error `error	15-Jun-2023 14:13:50	C:/Ruby27-x64/lib/ruby/gems/2.7.0/bundler/gems/stacker-7a69b9c08fe7/lib/stacker/stack/template.rb:37:in `rescue in remote': uninitialized constant Stacker::Stack::Template::AwS (NameError)`

An example https://bamboo.ansarada.com/deploy/viewDeploymentResult.action?deploymentResultId=477924729
```
build	15-Jun-2023 14:13:50	stack Ansarada-Interface-Production-Interface-AnsaradaDotCom-SvcHost-Shared-Paid exist in AWS
error	15-Jun-2023 14:13:50	C:/Ruby27-x64/lib/ruby/gems/2.7.0/bundler/gems/stacker-7a69b9c08fe7/lib/stacker/stack/template.rb:37:in `rescue in remote': uninitialized constant Stacker::Stack::Template::AwS (NameError)
error	15-Jun-2023 14:13:50	Did you mean?  Aws
error	15-Jun-2023 14:13:50		from C:/Ruby27-x64/lib/ruby/gems/2.7.0/bundler/gems/stacker-7a69b9c08fe7/lib/stacker/stack/template.rb:35:in `remote'
error	15-Jun-2023 14:13:50		from C:/Ruby27-x64/lib/ruby/gems/2.7.0/bundler/gems/stacker-7a69b9c08fe7/lib/stacker/stack/template.rb:46:in `diff'
error	15-Jun-2023 14:13:50	C:/Ruby27-x64/lib/ruby/2.7.0/json/common.rb:156:in `parse': 783: unexpected token at 'AWSTemplateFormatVersion: 2010-09-09 (JSON::ParserError)
```

## Solution

There is a typo in a reference -> fix that typo
