### PR TITLE
DOP-132859 remove `has_rdoc` attribute from stacker.gemspec file

### DIFF
--- a/stacker.gemspec
+++ b/stacker.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.files       = Dir['lib/**/*']
   s.executables = Dir['bin/*'].map{ |f| File.basename(f) }
 
-  s.has_rdoc    = false
-
   s.authors     = ['Cotap, Inc.']
   s.email       = %w[martin@cotap.com evan@cotap.com]
   s.homepage    = 'https://github.com/cotap/stacker'


### PR DESCRIPTION
Remove `has_doc` attribute from the gemspec file to avoid failure like this:

```
Error: NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
```

The issue happens only when execute `bundle install` via `Psake` task (`Psake` is a powershell module)